### PR TITLE
remove deprecated functions from exmaples

### DIFF
--- a/api_cpp/examples/102-High_level_movement/02-sequence.cpp
+++ b/api_cpp/examples/102-High_level_movement/02-sequence.cpp
@@ -253,6 +253,9 @@ int main(int argc, char **argv)
     success &= example_move_to_home_position(base);
     success &= example_create_sequence(base, base_cyclic);
 
+    // You can also refer to the 110-Waypoints examples for an alternate way to execute
+    // a trajectory defined by a series of waypoints in joint space or in Cartesian space
+
     // Close API session
     session_manager->CloseSession();
 

--- a/api_python/examples/102-Movement_high_level/01-move_angular_and_cartesian.py
+++ b/api_python/examples/102-Movement_high_level/01-move_angular_and_cartesian.py
@@ -148,72 +148,6 @@ def example_cartesian_action_movement(base, base_cyclic):
         print("Timeout on action notification wait")
     return finished
 
-def example_angular_trajectory_movement(base):
-    
-    constrained_joint_angles = Base_pb2.ConstrainedJointAngles()
-
-    actuator_count = base.GetActuatorCount()
-
-    # Place arm straight up
-    for joint_id in range(actuator_count.count):
-        joint_angle = constrained_joint_angles.joint_angles.joint_angles.add()
-        joint_angle.joint_identifier = joint_id
-        joint_angle.value = 0
-
-    e = threading.Event()
-    notification_handle = base.OnNotificationActionTopic(
-        check_for_end_or_abort(e),
-        Base_pb2.NotificationOptions()
-    )
-
-    print("Reaching joint angles...")
-    base.PlayJointTrajectory(constrained_joint_angles)
-
-
-    print("Waiting for movement to finish ...")
-    finished = e.wait(TIMEOUT_DURATION)
-    base.Unsubscribe(notification_handle)
-
-    if finished:
-        print("Joint angles reached")
-    else:
-        print("Timeout on action notification wait")
-    return finished
-
-
-def example_cartesian_trajectory_movement(base, base_cyclic):
-    
-    constrained_pose = Base_pb2.ConstrainedPose()
-
-    feedback = base_cyclic.RefreshFeedback()
-
-    cartesian_pose = constrained_pose.target_pose
-    cartesian_pose.x = feedback.base.tool_pose_x          # (meters)
-    cartesian_pose.y = feedback.base.tool_pose_y - 0.1    # (meters)
-    cartesian_pose.z = feedback.base.tool_pose_z - 0.2    # (meters)
-    cartesian_pose.theta_x = feedback.base.tool_pose_theta_x # (degrees)
-    cartesian_pose.theta_y = feedback.base.tool_pose_theta_y # (degrees)
-    cartesian_pose.theta_z = feedback.base.tool_pose_theta_z # (degrees)
-
-    e = threading.Event()
-    notification_handle = base.OnNotificationActionTopic(
-        check_for_end_or_abort(e),
-        Base_pb2.NotificationOptions()
-    )
-
-    print("Reaching cartesian pose...")
-    base.PlayCartesianTrajectory(constrained_pose)
-
-    print("Waiting for movement to finish ...")
-    finished = e.wait(TIMEOUT_DURATION)
-    base.Unsubscribe(notification_handle)
-
-    if finished:
-        print("Angular movement completed")
-    else:
-        print("Timeout on action notification wait")
-    return finished
-
 def main():
     
     # Import the utilities helper module
@@ -237,9 +171,8 @@ def main():
         success &= example_cartesian_action_movement(base, base_cyclic)
         success &= example_angular_action_movement(base)
 
-        success &= example_move_to_home_position(base)
-        success &= example_cartesian_trajectory_movement(base, base_cyclic)
-        success &= example_angular_trajectory_movement(base)
+        # You can also refer to the 110-Waypoints examples if you want to execute
+        # a trajectory defined by a series of waypoints in joint space or in Cartesian space
 
         return 0 if success else 1
 

--- a/api_python/examples/102-Movement_high_level/02-sequence.py
+++ b/api_python/examples/102-Movement_high_level/02-sequence.py
@@ -201,6 +201,9 @@ def main():
         success &= example_move_to_home_position(base)
         success &= example_create_sequence(base, base_cyclic)
         
+        # You can also refer to the 110-Waypoints examples for an alternate way to execute
+        # a trajectory defined by a series of waypoints in joint space or in Cartesian space
+
         return 0 if success else 1
 
 if __name__ == "__main__":


### PR DESCRIPTION
`PlayJointTrajectory` and `PlayCartesianTrajectory` were deprecated with the 2.3 Kortex release and they will be removed in a future release. They were replaced by the waypoint system (examples already exists for these).

I am removing them from the high level movement examples.