### PR TITLE
Correct manual cmake build with MSVC build tools

### DIFF
--- a/api_cpp/examples/CMakeLists.txt
+++ b/api_cpp/examples/CMakeLists.txt
@@ -41,7 +41,7 @@ endif()
 
 
 option(USE_CONAN "Use the Conan package manager to automatically fetch the Kortex API" ON)
-
+option(DOWNLOAD_API "Automatically download the API if conan is not used" ON)
 
 # Activate C++ 11
 set (CMAKE_CXX_STANDARD 11)
@@ -177,25 +177,30 @@ else() # Not using Conan
   endif()
 
   # Download the API
-  if(UNIX)
-    execute_process(COMMAND ./download_kortex_api.sh ${KORTEX_SUB_DIR}
-      WORKING_DIRECTORY ../scripts
-      RESULT_VARIABLE DOWNLOAD_API_RESULT
-      OUTPUT_VARIABLE DOWNLOAD_API_OUTPUT)
-    if(NOT DOWNLOAD_API_RESULT EQUAL 0)
-      message("Kortex API was not downloaded prior to running CMake.")
-      message(FATAL_ERROR ${DOWNLOAD_API_OUTPUT})
+  if(DOWNLOAD_API)
+    if(UNIX)
+      execute_process(COMMAND ./download_kortex_api.sh ${KORTEX_SUB_DIR}
+        WORKING_DIRECTORY ../scripts
+        RESULT_VARIABLE DOWNLOAD_API_RESULT
+        OUTPUT_VARIABLE DOWNLOAD_API_OUTPUT)
+      if(NOT DOWNLOAD_API_RESULT EQUAL 0)
+        message("Kortex API was not downloaded prior to running CMake.")
+        message(FATAL_ERROR ${DOWNLOAD_API_OUTPUT})
+      endif()
+    elseif(WIN32)
+      execute_process(COMMAND ./download_kortex_api.bat ${KORTEX_SUB_DIR}
+        WORKING_DIRECTORY ../scripts
+        RESULT_VARIABLE DOWNLOAD_API_RESULT
+        OUTPUT_VARIABLE DOWNLOAD_API_OUTPUT)
+      if(NOT DOWNLOAD_API_RESULT EQUAL 0)
+        message("Kortex API was not downloaded prior to running CMake.")
+        message(FATAL_ERROR ${DOWNLOAD_API_OUTPUT})
+      endif()
     endif()
+  endif()
+  if(UNIX)
     link_libraries(${KORTEX_DIR}lib/${KORTEX_LIB_SUBDIR}/libKortexApiCpp.a)
   elseif(WIN32)
-    execute_process(COMMAND ./download_kortex_api.bat ${KORTEX_SUB_DIR}
-      WORKING_DIRECTORY ../scripts
-      RESULT_VARIABLE DOWNLOAD_API_RESULT
-      OUTPUT_VARIABLE DOWNLOAD_API_OUTPUT)
-    if(NOT DOWNLOAD_API_RESULT EQUAL 0)
-      message("Kortex API was not downloaded prior to running CMake.")
-      message(FATAL_ERROR ${DOWNLOAD_API_OUTPUT})
-    endif()
     link_libraries(${KORTEX_DIR}lib/${KORTEX_LIB_SUBDIR}/KortexApiCpp.lib)
   endif()
 


### PR DESCRIPTION
Bring back the changes from commit 4409d9ab9d1f41819efeeba51dc872264b4bca67 that was lost when updating the repo with the 2.3 Kortex API.

One of the youtube video doesn't work because this fix is missing