### PR TITLE
Updating compatibility for Python3.10+

### DIFF
--- a/api_python/examples/000-Getting_Started/01-api_creation.py
+++ b/api_python/examples/000-Getting_Started/01-api_creation.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:   
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.TCPTransport import TCPTransport
 from kortex_api.RouterClient import RouterClient
 from kortex_api.SessionManager import SessionManager

--- a/api_python/examples/000-Getting_Started/02-protobuf_object_manipulation.py
+++ b/api_python/examples/000-Getting_Started/02-protobuf_object_manipulation.py
@@ -12,6 +12,13 @@
 #
 ###
 
+import sys
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.messages import Base_pb2
 

--- a/api_python/examples/000-Getting_Started/03-api_mechanism.py
+++ b/api_python/examples/000-Getting_Started/03-api_mechanism.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.RouterClient import RouterClientSendOptions
 
 from kortex_api.autogen.client_stubs.DeviceConfigClientRpc import DeviceConfigClient

--- a/api_python/examples/000-Getting_Started/04-error_management.py
+++ b/api_python/examples/000-Getting_Started/04-error_management.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.DeviceConfigClientRpc import DeviceConfigClient
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 

--- a/api_python/examples/000-Getting_Started/05-notification.py
+++ b/api_python/examples/000-Getting_Started/05-notification.py
@@ -16,6 +16,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.DeviceConfigClientRpc import DeviceConfigClient
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 

--- a/api_python/examples/100-Overview/01-devices_routing.py
+++ b/api_python/examples/100-Overview/01-devices_routing.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.RouterClient import RouterClientSendOptions
 
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient

--- a/api_python/examples/100-Overview/02-protection_zones_configuration.py
+++ b/api_python/examples/100-Overview/02-protection_zones_configuration.py
@@ -17,6 +17,11 @@ import os
 import time
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 
 from kortex_api.autogen.messages import Base_pb2, Common_pb2

--- a/api_python/examples/102-Movement_high_level/01-move_angular_and_cartesian.py
+++ b/api_python/examples/102-Movement_high_level/01-move_angular_and_cartesian.py
@@ -17,6 +17,11 @@ import os
 import time
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.BaseCyclicClientRpc import BaseCyclicClient
 

--- a/api_python/examples/102-Movement_high_level/02-sequence.py
+++ b/api_python/examples/102-Movement_high_level/02-sequence.py
@@ -17,6 +17,11 @@ import sys
 import os
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.BaseCyclicClientRpc import BaseCyclicClient
 

--- a/api_python/examples/102-Movement_high_level/03-twist_command.py
+++ b/api_python/examples/102-Movement_high_level/03-twist_command.py
@@ -17,6 +17,11 @@ import sys
 import os
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.TCPTransport import TCPTransport
 from kortex_api.RouterClient import RouterClient
 from kortex_api.SessionManager import SessionManager

--- a/api_python/examples/102-Movement_high_level/04-send_joint_speeds.py
+++ b/api_python/examples/102-Movement_high_level/04-send_joint_speeds.py
@@ -17,6 +17,11 @@ import os
 import time
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 from kortex_api.autogen.client_stubs.DeviceConfigClientRpc import DeviceConfigClient

--- a/api_python/examples/103-Gen3_uart_bridge/01-uart_bridge.py
+++ b/api_python/examples/103-Gen3_uart_bridge/01-uart_bridge.py
@@ -45,6 +45,11 @@ import os
 import socket
 import select
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 from kortex_api.autogen.client_stubs.InterconnectConfigClientRpc import InterconnectConfigClient

--- a/api_python/examples/104-Gen3_gpio_bridge/01-gpio_bridge.py
+++ b/api_python/examples/104-Gen3_gpio_bridge/01-gpio_bridge.py
@@ -59,6 +59,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 from kortex_api.autogen.client_stubs.InterconnectConfigClientRpc import InterconnectConfigClient
 

--- a/api_python/examples/105-Gen3_i2c_bridge/01-i2c_bridge.py
+++ b/api_python/examples/105-Gen3_i2c_bridge/01-i2c_bridge.py
@@ -54,6 +54,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 from kortex_api.autogen.client_stubs.InterconnectConfigClientRpc import InterconnectConfigClient
 

--- a/api_python/examples/106-Gripper_command/01-gripper_command.py
+++ b/api_python/examples/106-Gripper_command/01-gripper_command.py
@@ -16,6 +16,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.messages import Base_pb2
 

--- a/api_python/examples/107-Gripper_low_level_command/01-gripper_low_level_command.py
+++ b/api_python/examples/107-Gripper_low_level_command/01-gripper_low_level_command.py
@@ -53,6 +53,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kbhit import KBHit
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.BaseCyclicClientRpc import BaseCyclicClient

--- a/api_python/examples/108-Gen3_torque_control/01-torque_control_cyclic.py
+++ b/api_python/examples/108-Gen3_torque_control/01-torque_control_cyclic.py
@@ -46,6 +46,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.ActuatorConfigClientRpc import ActuatorConfigClient
 from kortex_api.autogen.client_stubs.ActuatorCyclicClientRpc import ActuatorCyclicClient
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient

--- a/api_python/examples/109-Gen3_ethernet_bridge/01-ethernet_bridge_configuration.py
+++ b/api_python/examples/109-Gen3_ethernet_bridge/01-ethernet_bridge_configuration.py
@@ -16,6 +16,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 from kortex_api.autogen.client_stubs.InterconnectConfigClientRpc import InterconnectConfigClient
 from kortex_api.autogen.messages import Session_pb2, Base_pb2, Common_pb2, InterconnectConfig_pb2, DeviceManager_pb2

--- a/api_python/examples/110-Waypoints/01-send_angular_wapoint_trajectory.py
+++ b/api_python/examples/110-Waypoints/01-send_angular_wapoint_trajectory.py
@@ -17,6 +17,11 @@ import os
 import time
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.BaseCyclicClientRpc import BaseCyclicClient
 

--- a/api_python/examples/110-Waypoints/02-send_cartesian_waypoint_trajectory.py
+++ b/api_python/examples/110-Waypoints/02-send_cartesian_waypoint_trajectory.py
@@ -17,6 +17,11 @@ import os
 import time
 import threading
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 from kortex_api.autogen.client_stubs.BaseCyclicClientRpc import BaseCyclicClient
 

--- a/api_python/examples/111-kinematics/01-compute-kinematics.py
+++ b/api_python/examples/111-kinematics/01-compute-kinematics.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.BaseClientRpc import BaseClient
 
 from kortex_api.autogen.messages import Base_pb2

--- a/api_python/examples/500-Gen3_vision_configuration/01-vision_intrinsics.py
+++ b/api_python/examples/500-Gen3_vision_configuration/01-vision_intrinsics.py
@@ -15,6 +15,11 @@
 import sys
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.VisionConfigClientRpc import VisionConfigClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 

--- a/api_python/examples/500-Gen3_vision_configuration/02-vision_extrinsics.py
+++ b/api_python/examples/500-Gen3_vision_configuration/02-vision_extrinsics.py
@@ -15,6 +15,11 @@
 import sys 
 import os
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.VisionConfigClientRpc import VisionConfigClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 

--- a/api_python/examples/500-Gen3_vision_configuration/03-vision_sensor_focus_action.py
+++ b/api_python/examples/500-Gen3_vision_configuration/03-vision_sensor_focus_action.py
@@ -24,6 +24,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.VisionConfigClientRpc import VisionConfigClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient
 

--- a/api_python/examples/500-Gen3_vision_configuration/04-vision_sensor_options.py
+++ b/api_python/examples/500-Gen3_vision_configuration/04-vision_sensor_options.py
@@ -23,6 +23,11 @@ import sys
 import os
 import time
 
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
+
 from kortex_api.autogen.client_stubs.VisionConfigClientRpc import VisionConfigClient
 from kortex_api.autogen.client_stubs.DeviceConfigClientRpc import DeviceConfigClient
 from kortex_api.autogen.client_stubs.DeviceManagerClientRpc import DeviceManagerClient

--- a/api_python/examples/utilities.py
+++ b/api_python/examples/utilities.py
@@ -1,4 +1,10 @@
 import argparse
+import sys
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 10:  
+    import collections
+    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
+    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
 
 from kortex_api.TCPTransport import TCPTransport
 from kortex_api.UDPTransport import UDPTransport


### PR DESCRIPTION
As mentioned in #191 the current Python API does not support python versions 3.10+ 
It will produce the following error for any import from `kortex_api`
```bash
Error: "module 'collections' has no attribute 'MutableMapping'
```
The reason being attribute `MutableMapping` was moved to `collections.abc` in python 3.10
The solution is to add the following lines for any python file that imports the `kortex_api`
```python
import sys
if sys.version_info.major == 3 and sys.version_info.minor >= 10:   
    import collections
    setattr(collections, "MutableMapping", collections.abc.MutableMapping)
    setattr(collections,"MutableSequence", collections.abc.MutableSequence)
```

The method was tested using the Kinova API 2.6.0 and maintainers may have modified their approach with recent developments. This solution is useful if downgrading protobuf is undesired.